### PR TITLE
Prevent divide by zero errors in warmup

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,21 +141,21 @@ After the execution you should wait one or two trades of the bot before adding a
 By running the script without parameters, it will warm up the bots default database with all available coins for the bridge.
 
 ```shell
-pyhton3 database_warmup.py
+python3 database_warmup.py
 ```
 
 If you want to specify a separate db file you can use the -d or --dbfile parameter.
 If not provided, the script will use the bots default db file.
 
 ```shell
-pyhton3 database_warmup.py -d data/warmup.db
+python3 database_warmup.py -d data/warmup.db
 ```
 
 You can also specify the coins you want to warmup with the -c or --coinlist parameter.
 If not provided the script will warmup all coins available for the bridge.
 
 ```shell
-pyhton3 database_warmup.py -c 'ADA BTC ETH LTC'
+python3 database_warmup.py -c 'ADA BTC ETH LTC'
 ```
 
 ## Developing

--- a/binance_trade_bot/database_warmup.py
+++ b/binance_trade_bot/database_warmup.py
@@ -85,7 +85,7 @@ class WarmUpTrader(AutoTrader):
                     continue
 
                 to_coin_price = self.manager.get_buy_price(pair.to_coin + self.config.BRIDGE)
-                if to_coin_price is None:
+                if to_coin_price is None or to_coin_price == 0:
                     self.logger.info(
                         "Skipping initializing {}, symbol not found".format(pair.to_coin + self.config.BRIDGE)
                     )


### PR DESCRIPTION
Some pairs in the default supported list, are not matched with the default bridge.

e.g. `LENDUSDT`

and the warmup fails due to divide by zero errors as the price fetched is 0.0.

