### PR TITLE
Fees Calculations

### DIFF
--- a/binance_trade_bot/binance_api_manager.py
+++ b/binance_trade_bot/binance_api_manager.py
@@ -66,7 +66,7 @@ class BinanceAPIManager:
             else self._buy_quantity(origin_coin.symbol, target_coin.symbol)
         )
 
-        fee_amount = amount_trading * base_fee * 0.75
+        fee_amount = amount_trading * base_fee * 0.00075
         if origin_coin.symbol == "BNB":
             fee_amount_bnb = fee_amount
         else:
@@ -78,7 +78,7 @@ class BinanceAPIManager:
         bnb_balance = self.get_currency_balance("BNB")
 
         if bnb_balance >= fee_amount_bnb:
-            return base_fee * 0.75
+            return base_fee * 0.00075
         return base_fee
 
     def get_account(self):


### PR DESCRIPTION
Hi there, I think there's a mistake on fees calculation using BNB. 
If you're using BNB, they take 0.075% fees equals to 0.00075, without BNB they took 0.1% equals to 0.001

```
fees = client.get_trade_fee(symbol = "VETUSDT")
{'success': True, 'tradeFee': [{'maker': 0.001, 'symbol': 'VETUSDT', 'taker': 0.001}]}
```

Please correct me if I'm wrong, I think the calculation were there for a long time.