### PR TITLE
Adding itsdangerous==2.0.1 as requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ unicorn-fy==0.11.0
 xmltodict==0.12.0
 diskcache==5.2.1
 Pebble==4.6.1
+itsdangerous==2.0.1


### PR DESCRIPTION
Flask 1.1.2 is set up to require itsdangerous >= 0.24. The latest released (itsdangerous) version (2.10) deprecated the json API. To continue using Flask 1.1.2, you need to require at most itdangerous 2.0.1 (not 2.10)